### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Chain of Draft Server is a powerful AI-driven tool that helps developers make better decisions through systematic, iterative refinement of thoughts and designs. It integrates seamlessly with popular AI agents and provides a structured approach to reasoning, API design, architecture decisions, code reviews, and implementation planning.
 
+<a href="https://glama.ai/mcp/servers/exar7zd4f0">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/exar7zd4f0/badge" alt="Chain of Draft Thinking MCP server" />
+</a>
+
 ## 🌟 Features
 
 ### Core Capabilities

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ MIT License - see the [LICENSE](LICENSE) file for details.
 * Special thanks to the MCP community
 * Inspired by systematic reasoning methodologies
 
+
 ---
 
 Made with 🧠 by @bsmi021


### PR DESCRIPTION
This PR adds a badge for the [Chain of Draft Thinking](https://glama.ai/mcp/servers/exar7zd4f0) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/exar7zd4f0">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/exar7zd4f0/badge" alt="Chain of Draft Thinking MCP server" />
</a>


Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.